### PR TITLE
refactored use of refs according to React docs

### DIFF
--- a/src/P5Wrapper.js
+++ b/src/P5Wrapper.js
@@ -4,7 +4,7 @@ import p5 from 'p5';
 export default class P5Wrapper extends React.Component {
 
   componentDidMount() {
-    this.canvas = new p5(this.props.sketch, this.refs.wrapper);
+    this.canvas = new p5(this.props.sketch, this.wrapper);
     this.canvas.myCustomRedrawAccordingToNewPropsHandler(this.props);
   }
 
@@ -15,6 +15,6 @@ export default class P5Wrapper extends React.Component {
   }
 
   render() {
-    return <div ref="wrapper"></div>;
+    return <div ref={wrapper => this.wrapper = wrapper}></div>;
   }
 }


### PR DESCRIPTION
using refs with a string is mentioned as bad-practice in the React docs, so i refactored the P5Wrapper component to align with the doc's suggestions

From the docs:
>  If you worked with React before, you might be familiar with an older API where the ref attribute is a string, like "textInput", and the DOM node is accessed as this.refs.textInput. We advise against it because string refs have some issues, are considered legacy, and are likely to be removed in one of the future releases. If you're currently using this.refs.textInput to access refs, we recommend the callback pattern instead.
[https://facebook.github.io/react/docs/refs-and-the-dom.html](url)