### PR TITLE
fix: #13 performance degradation

### DIFF
--- a/src/P5Wrapper.js
+++ b/src/P5Wrapper.js
@@ -12,12 +12,16 @@ export default class P5Wrapper extends React.Component {
 
   componentWillReceiveProps(newprops) {
     if(this.props.sketch !== newprops.sketch){
-      this.wrapper.removeChild(this.wrapper.childNodes[0]);
+      this.canvas.remove();
       this.canvas = new p5(newprops.sketch, this.wrapper);
     }
     if( this.canvas.myCustomRedrawAccordingToNewPropsHandler ) {
       this.canvas.myCustomRedrawAccordingToNewPropsHandler(newprops);
     }
+  }
+
+  componentWillUnmount() {
+    this.canvas.remove();
   }
 
   render() {


### PR DESCRIPTION
Removing the dom node does not remove the JS objects associated to it causing a memory leak (see eugene lazutkin comment https://stackoverflow.com/questions/683366/remove-all-the-children-dom-elements-in-div). 

Using `this.canvas.remove()` instead of `this.wrapper.removeChild(this.wrapper.childNodes[0]);` seems to fix this.