### PR TITLE
easy cleanup when component unmounts

### DIFF
--- a/src/P5Wrapper.js
+++ b/src/P5Wrapper.js
@@ -1,26 +1,29 @@
-import React from 'react';
-import p5 from 'p5';
+import React from "react";
+import p5 from "p5";
 
 export default class P5Wrapper extends React.Component {
+	componentDidMount() {
+		this.canvas = new p5(this.props.sketch, this.wrapper);
+		if (this.canvas.myCustomRedrawAccordingToNewPropsHandler) {
+			this.canvas.myCustomRedrawAccordingToNewPropsHandler(this.props);
+		}
+	}
 
-  componentDidMount() {
-    this.canvas = new p5(this.props.sketch, this.wrapper);
-    if( this.canvas.myCustomRedrawAccordingToNewPropsHandler ) {
-      this.canvas.myCustomRedrawAccordingToNewPropsHandler(this.props);
-    }
-  }
+	componentWillReceiveProps(newprops) {
+		if (this.props.sketch !== newprops.sketch) {
+			this.wrapper.removeChild(this.wrapper.childNodes[0]);
+			this.canvas = new p5(newprops.sketch, this.wrapper);
+		}
+		if (this.canvas.myCustomRedrawAccordingToNewPropsHandler) {
+			this.canvas.myCustomRedrawAccordingToNewPropsHandler(newprops);
+		}
+	}
 
-  componentWillReceiveProps(newprops) {
-    if(this.props.sketch !== newprops.sketch){
-      this.wrapper.removeChild(this.wrapper.childNodes[0]);
-      this.canvas = new p5(newprops.sketch, this.wrapper);
-    }
-    if( this.canvas.myCustomRedrawAccordingToNewPropsHandler ) {
-      this.canvas.myCustomRedrawAccordingToNewPropsHandler(newprops);
-    }
-  }
+	componentWillUnmount() {
+		this.canvas.remove();
+	}
 
-  render() {
-    return <div ref={wrapper => this.wrapper = wrapper}></div>;
-  }
+	render() {
+		return <div ref={wrapper => (this.wrapper = wrapper)} />;
+	}
 }


### PR DESCRIPTION
Simplifies the cleanup needed when the P5 Wrapper unmounts and prevents memory leaks. Instead of having to deal with cleanup in the sketch, will automatically remove the canvas in the wrapper. 