### PR TITLE
Improves custom redraw example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export default function sketch (p) {
   };
 
   p.myCustomRedrawAccordingToNewPropsHandler = function (props) {
-    if (props.rotation){
+    if (props.rotation !== null){
       rotation = props.rotation * Math.PI / 180;
     }
   };


### PR DESCRIPTION
I recommend changing `if(props.rotation)` to `if (props.rotation !== null)` to avoid the situation where `props.rotation` is 0, and should update the drawing to use the value `0`, but since `0` is considered `false`, in Javascript the condition is false.

I actually just ran into this bug in my code by copying this example, so I thought I'd suggest this change.