### PR TITLE
Build demo into dist folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,9 @@
-# This file is for unifying the coding style for different editors and IDEs
-# editorconfig.org
 root = true
 
 [*]
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = true
-indent_style = tab
-
-[*.json]
-indent_style = space
+end_of_line = lf
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ coverage.html
 # Dependency directory
 node_modules
 
-# Example build directory
-example/dist
 .publish
 lib
 dist

--- a/.npmignore
+++ b/.npmignore
@@ -16,8 +16,6 @@ coverage.html
 # Dependency directory
 node_modules
 
-# Example build directory
-example/dist
 .publish
 dist
 example

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "build": "npm run clean && tsc",
     "build-demo": "npm run clean && webpack --config webpack.config.demo.js --mode production",
     "clean": "rimraf dist",
-    "deploy": "gh-pages -d example/dist",
+    "deploy": "gh-pages -d dist",
     "publish-demo": "npm run build-demo && npm run deploy",
     "publish-npm-package": "npm run build && npm publish"
   },

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -1,39 +1,39 @@
-const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const htmlWebpackPlugin = new HtmlWebpackPlugin({
-  template: path.join(__dirname, './example/src/index.html'),
-  filename: './index.html'
+  template: path.join(__dirname, "./example/src/index.html"),
+  filename: "./index.html"
 });
 
 module.exports = {
-  entry: path.join(__dirname, './example/src/app.jsx'),
+  entry: path.join(__dirname, "./example/src/app.jsx"),
   output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js'
+    path: path.join(__dirname, "dist"),
+    filename: "bundle.js"
   },
   module: {
     rules: [
       {
         test: /\.tsx?$/,
-        loader: 'ts-loader'
+        loader: "ts-loader"
       },
       {
         test: /\.(js|jsx)$/,
-        use: 'babel-loader',
+        use: "babel-loader",
         exclude: /node_modules/
       },
       {
         test: /\.css$/,
         use: [
-          'style-loader',
-          'css-loader'
+          "style-loader",
+          "css-loader"
         ],
       }
     ]
   },
   plugins: [htmlWebpackPlugin],
   resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.json']
+    extensions: [".ts", ".tsx", ".js", ".json"]
   },
   devServer: {
     port: 3001

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -8,7 +8,7 @@ const htmlWebpackPlugin = new HtmlWebpackPlugin({
 module.exports = {
   entry: path.join(__dirname, './example/src/app.jsx'),
   output: {
-    path: path.join(__dirname, 'example/dist'),
+    path: path.join(__dirname, 'dist'),
     filename: 'bundle.js'
   },
   module: {

--- a/webpack.config.demo.js
+++ b/webpack.config.demo.js
@@ -1,38 +1,41 @@
 const path = require('path');
-const HtmlWebpackPlugin = require("html-webpack-plugin");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const htmlWebpackPlugin = new HtmlWebpackPlugin({
-    template: path.join(__dirname, "./example/src/index.html"),
-    filename: "./index.html"
+  template: path.join(__dirname, './example/src/index.html'),
+  filename: './index.html'
 });
 
 module.exports = {
-
-  entry: path.join(__dirname, "./example/src/app.jsx"),
+  entry: path.join(__dirname, './example/src/app.jsx'),
   output: {
-      path: path.join(__dirname, "example/dist"),
-      filename: "bundle.js"
+    path: path.join(__dirname, 'example/dist'),
+    filename: 'bundle.js'
   },
   module: {
     rules: [
-        // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
-        { test: /\.tsx?$/, loader: "ts-loader" },
-        {
-          test: /\.(js|jsx)$/,
-          use: "babel-loader",
-          exclude: /node_modules/
-        },
-        {
-          test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
-        }
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader'
+      },
+      {
+        test: /\.(js|jsx)$/,
+        use: 'babel-loader',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/,
+        use: [
+          'style-loader',
+          'css-loader'
+        ],
+      }
     ]
-},
+  },
   plugins: [htmlWebpackPlugin],
   resolve: {
-    // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [".ts", ".tsx", ".js", ".json"]
-},
+    extensions: ['.ts', '.tsx', '.js', '.json']
+  },
   devServer: {
-      port: 3001
+    port: 3001
   },
 };


### PR DESCRIPTION
This MR updates the Webpack config to build a demo into the `dist` folder.

#### What was changed?

- Format Webpack config.
- Build demo into the `dist` folder.
- Update `deploy` script with a new build directory path.
- Remove example build directory from ignore files.
- Use space indent in the `.editorconfig`.
- Prefer to use double quotes.