### PR TITLE
Add documentation for Typescript and resolve typing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Then just open `http://localhost:3001` in a browser.
 
 ## Usage
 
+### Javascript
+
 ```js
 import React from "react";
 import { ReactP5Wrapper } from "react-p5-wrapper";
@@ -63,6 +65,118 @@ function sketch(p5) {
 
 export default function App() {
   return <ReactP5Wrapper sketch={sketch} />;
+}
+```
+
+### Typescript
+
+Typescript sketches can be declared in two different ways, below you will find
+two ways to declare a sketch, both examples do the exact same thing.
+
+In short though, the `ReactP5Wrapper` component requires you to pass a `sketch`
+prop. The `sketch` prop is typed as a `(instance: P5Instance): void;`. As long
+as the function declaration of your sketch is set to take in a single argument
+of type `P5Instance`, you are good to go!
+
+#### Option 1: Declaring a sketch using the `P5Instance` type
+
+```ts
+import React, { useState, useEffect } from "react";
+import { ReactP5Wrapper, P5Instance } from "react-p5-wrapper";
+
+function sketch(p5: P5Instance) {
+  let rotation = 0;
+
+  p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
+
+  p5.updateWithProps = props => {
+    if (props.rotation) {
+      rotation = (props.rotation * Math.PI) / 180;
+    }
+  };
+
+  p5.draw = () => {
+    p5.background(100);
+    p5.normalMaterial();
+    p5.noStroke();
+    p5.push();
+    p5.rotateY(rotation);
+    p5.box(100);
+    p5.pop();
+  };
+}
+
+export default function App() {
+  const [rotation, setRotation] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setRotation(rotation => rotation + 100),
+      100
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return <ReactP5Wrapper sketch={sketch} rotation={rotation} />;
+}
+```
+
+#### Option 2: Declaring a sketch using the `Sketch` type
+
+Using the `Sketch` type has one nice benefit over using `P5Instance` and that is
+that the `p5` argument passed to the sketch function is auto-typed as a
+`P5Instance` for you.
+
+> Sidenote:
+>
+> In general it comes down to personal preference as to how you declare your
+> sketches and there is nothing wrong with using the `P5Instance` manually in a
+> regular `function` declaration.
+
+```ts
+import React, { useState, useEffect } from "react";
+import { ReactP5Wrapper, Sketch } from "react-p5-wrapper";
+
+const sketch: Sketch = p5 => {
+  let rotation = 0;
+
+  p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
+
+  p5.updateWithProps = props => {
+    if (props.rotation) {
+      rotation = (props.rotation * Math.PI) / 180;
+    }
+  };
+
+  p5.draw = () => {
+    p5.background(100);
+    p5.normalMaterial();
+    p5.noStroke();
+    p5.push();
+    p5.rotateY(rotation);
+    p5.box(100);
+    p5.pop();
+  };
+};
+
+export default function App() {
+  const [rotation, setRotation] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(
+      () => setRotation(rotation => rotation + 100),
+      100
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return <ReactP5Wrapper sketch={sketch} rotation={rotation} />;
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
+        "@types/p5": "^1.3.1",
         "deep-equal": "^2.0.5",
         "p5": "^1.4.0"
       },
@@ -21,7 +22,6 @@
         "@testing-library/react": "^12.1.0",
         "@types/deep-equal": "^1.0.1",
         "@types/jest": "^27.0.2",
-        "@types/p5": "^1.3.1",
         "@types/react": "^17.0.24",
         "@types/react-dom": "^17.0.9",
         "@typescript-eslint/eslint-plugin": "^4.31.2",
@@ -62,8 +62,6 @@
       "integrity": "sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==",
       "dev": true,
       "dependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -3056,8 +3054,7 @@
     "node_modules/@types/p5": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/p5/-/p5-1.3.1.tgz",
-      "integrity": "sha512-Z/rBqimKVE4u2H+BDLxocBBMhufJiUYcC5IMcSRTfwhu5bf5ImUZHlFQUSDa2EMlB08wtk2DGijU4BmILk0w+A==",
-      "dev": true
+      "integrity": "sha512-Z/rBqimKVE4u2H+BDLxocBBMhufJiUYcC5IMcSRTfwhu5bf5ImUZHlFQUSDa2EMlB08wtk2DGijU4BmILk0w+A=="
     },
     "node_modules/@types/prettier": {
       "version": "2.4.0",
@@ -4390,7 +4387,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5524,8 +5520,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8301,7 +8296,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
@@ -9558,9 +9552,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -11303,9 +11294,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.57.0.tgz",
       "integrity": "sha512-bKQIh1rWKofRee6mv8SrF2HdP6pea5QkwBZSMImJysFj39gQuiV8MEPBjXOCpzk3wSYp63M2v2wkWBmFC8O/rg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15894,8 +15882,7 @@
     "@types/p5": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/p5/-/p5-1.3.1.tgz",
-      "integrity": "sha512-Z/rBqimKVE4u2H+BDLxocBBMhufJiUYcC5IMcSRTfwhu5bf5ImUZHlFQUSDa2EMlB08wtk2DGijU4BmILk0w+A==",
-      "dev": true
+      "integrity": "sha512-Z/rBqimKVE4u2H+BDLxocBBMhufJiUYcC5IMcSRTfwhu5bf5ImUZHlFQUSDa2EMlB08wtk2DGijU4BmILk0w+A=="
     },
     "@types/prettier": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "url": "https://github.com/jamesrweb/react-p5-wrapper/issues"
   },
   "dependencies": {
+    "@types/p5": "^1.3.1",
     "deep-equal": "^2.0.5",
     "p5": "^1.4.0"
   },
@@ -73,7 +74,6 @@
     "@testing-library/react": "^12.1.0",
     "@types/deep-equal": "^1.0.1",
     "@types/jest": "^27.0.2",
-    "@types/p5": "^1.3.1",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@typescript-eslint/eslint-plugin": "^4.31.2",


### PR DESCRIPTION
Fixes issue #116
Fixes issue #117

## Proposed Changes

- Require `@types/p5` as a dependency and not just on development (Should resolve #117)
- Add typescript documentation for the `P5Instance` and `Sketch` types. (Resolves #116)
