### PR TITLE
Fix broken links after transferring repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ A component to integrate [p5.js](https://p5js.org/) sketches into
 ### Live demo
 
 A live demo can be viewed at
-[jamesrweb.github.io/react-p5-wrapper](http://jamesrweb.github.io/react-p5-wrapper/).
+[p5-wrapper.github.io/react](https://p5-wrapper.github.io/react/).
 
 ### Examples
 
 The repository contains further
-[examples](https://github.com/jamesrweb/react-p5-wrapper/tree/master/example/src).
+[examples](https://github.com/P5-wrapper/react/tree/master/example/sketches).
 
 To try them out for yourself, run the following:
 
 ```sh
-git clone git@github.com:jamesrweb/react-p5-wrapper.git
-cd react-p5-wrapper
+git clone git@github.com:P5-wrapper/react.git
+cd react
 npm install
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-p5-wrapper
 
-A component to integrate [p5.js](https://p5js.org/) sketches into
+A component to integrate [P5.js](https://p5js.org/) sketches into
 [React](https://reactjs.org/) apps.
 
 ## Demo & Examples
@@ -8,7 +8,7 @@ A component to integrate [p5.js](https://p5js.org/) sketches into
 ### Live demo
 
 A live demo can be viewed at
-[p5-wrapper.github.io/react](https://p5-wrapper.github.io/react/).
+[P5-wrapper.github.io/react](https://P5-wrapper.github.io/react/).
 
 ### Examples
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,14 +1,12 @@
 <!DOCTYPE html>
-
 <head>
   <title>react-p5-wrapper</title>
 </head>
-
 <body>
   <div class="container">
     <h1>react-p5-wrapper</h1>
     <h2>
-      <a href="https://github.com/jamesrweb/react-p5-wrapper">View project on GitHub</a>
+      <a href="https://github.com/P5-wrapper/react">View project on GitHub</a>
     </h2>
     <div id="app"></div>
     <div class="footer">
@@ -16,7 +14,7 @@
       <script>
         new Date().getFullYear() > 2016 && document.write(new Date().getFullYear());
       </script>
-      <a href="https://github.com/jamesrweb/react-p5-wrapper/graphs/contributors">Contributors</a>.
+      <a href="https://github.com/P5-wrapper/react/graphs/contributors">Contributors</a>.
     </div>
   </div>
 </body>


### PR DESCRIPTION
This MR corrects the links in the example and README after transferring the library from the personal account to the organization.

## Proposed Changes

- Fix broken links after transferring repo.
