### PR TITLE
Add new example of declaring sketch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Then just open `http://localhost:3001` in a browser.
 
 ### Javascript
 
+#### Option 1: Declaring a sketch as a function
+
 ```js
 import React from "react";
 import { ReactP5Wrapper } from "react-p5-wrapper";
@@ -61,6 +63,41 @@ function sketch(p5) {
     p5.plane(100);
     p5.pop();
   };
+}
+
+export default function App() {
+  return <ReactP5Wrapper sketch={sketch} />;
+}
+```
+
+#### Option 2: Declaring a sketch using abstracted setup and draw functions
+
+```js
+import React, { useState, useEffect } from "react";
+import { ReactP5Wrapper } from "react-p5-wrapper";
+
+function setup(p5) {
+  return () => {
+    p5.createCanvas(600, 400, p5.WEBGL);
+  };
+}
+
+function draw(p5) {
+  return () => {
+    p5.background(250);
+    p5.normalMaterial();
+    p5.push();
+    p5.rotateZ(p5.frameCount * 0.01);
+    p5.rotateX(p5.frameCount * 0.01);
+    p5.rotateY(p5.frameCount * 0.01);
+    p5.plane(100);
+    p5.pop();
+  };
+}
+
+function sketch(p5) {
+  p5.setup = setup(p5);
+  p5.draw = draw(p5);
 }
 
 export default function App() {

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ export function App() {
 ### Using abstracted setup and draw functions
 
 ```js
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { ReactP5Wrapper } from "react-p5-wrapper";
 
 function setup(p5) {

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Then just open `http://localhost:3001` in a browser.
 
 ### Javascript
 
-#### Option 1: Declaring a sketch as a function
-
 ```js
 import React from "react";
 import { ReactP5Wrapper } from "react-p5-wrapper";
@@ -63,41 +61,6 @@ function sketch(p5) {
     p5.plane(100);
     p5.pop();
   };
-}
-
-export function App() {
-  return <ReactP5Wrapper sketch={sketch} />;
-}
-```
-
-#### Option 2: Declaring a sketch using abstracted setup and draw functions
-
-```js
-import React, { useState, useEffect } from "react";
-import { ReactP5Wrapper } from "react-p5-wrapper";
-
-function setup(p5) {
-  return () => {
-    p5.createCanvas(600, 400, p5.WEBGL);
-  };
-}
-
-function draw(p5) {
-  return () => {
-    p5.background(250);
-    p5.normalMaterial();
-    p5.push();
-    p5.rotateZ(p5.frameCount * 0.01);
-    p5.rotateX(p5.frameCount * 0.01);
-    p5.rotateY(p5.frameCount * 0.01);
-    p5.plane(100);
-    p5.pop();
-  };
-}
-
-function sketch(p5) {
-  p5.setup = setup(p5);
-  p5.draw = draw(p5);
 }
 
 export function App() {
@@ -171,6 +134,41 @@ const sketch: Sketch = p5 => {
     p5.pop();
   };
 };
+
+export function App() {
+  return <ReactP5Wrapper sketch={sketch} />;
+}
+```
+
+### Using abstracted setup and draw functions
+
+```js
+import React, { useState, useEffect } from "react";
+import { ReactP5Wrapper } from "react-p5-wrapper";
+
+function setup(p5) {
+  return () => {
+    p5.createCanvas(600, 400, p5.WEBGL);
+  };
+}
+
+function draw(p5) {
+  return () => {
+    p5.background(250);
+    p5.normalMaterial();
+    p5.push();
+    p5.rotateZ(p5.frameCount * 0.01);
+    p5.rotateX(p5.frameCount * 0.01);
+    p5.rotateY(p5.frameCount * 0.01);
+    p5.plane(100);
+    p5.pop();
+  };
+}
+
+function sketch(p5) {
+  p5.setup = setup(p5);
+  p5.draw = draw(p5);
+}
 
 export function App() {
   return <ReactP5Wrapper sketch={sketch} />;

--- a/README.md
+++ b/README.md
@@ -118,46 +118,26 @@ of type `P5Instance`, you are good to go!
 #### Option 1: Declaring a sketch using the `P5Instance` type
 
 ```ts
-import React, { useState, useEffect } from "react";
-import { ReactP5Wrapper, P5Instance } from "react-p5-wrapper";
+import React from "react";
+import { ReactP5Wrapper } from "react-p5-wrapper";
 
 function sketch(p5: P5Instance) {
-  let rotation = 0;
-
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
 
-  p5.updateWithProps = props => {
-    if (props.rotation) {
-      rotation = (props.rotation * Math.PI) / 180;
-    }
-  };
-
   p5.draw = () => {
-    p5.background(100);
+    p5.background(250);
     p5.normalMaterial();
-    p5.noStroke();
     p5.push();
-    p5.rotateY(rotation);
-    p5.box(100);
+    p5.rotateZ(p5.frameCount * 0.01);
+    p5.rotateX(p5.frameCount * 0.01);
+    p5.rotateY(p5.frameCount * 0.01);
+    p5.plane(100);
     p5.pop();
   };
 }
 
 export function App() {
-  const [rotation, setRotation] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(
-      () => setRotation(rotation => rotation + 100),
-      100
-    );
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
-  return <ReactP5Wrapper sketch={sketch} rotation={rotation} />;
+  return <ReactP5Wrapper sketch={sketch} />;
 }
 ```
 
@@ -174,46 +154,26 @@ that the `p5` argument passed to the sketch function is auto-typed as a
 > regular `function` declaration.
 
 ```ts
-import React, { useState, useEffect } from "react";
-import { ReactP5Wrapper, Sketch } from "react-p5-wrapper";
+import React from "react";
+import { ReactP5Wrapper } from "react-p5-wrapper";
 
 const sketch: Sketch = p5 => {
-  let rotation = 0;
-
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
 
-  p5.updateWithProps = props => {
-    if (props.rotation) {
-      rotation = (props.rotation * Math.PI) / 180;
-    }
-  };
-
   p5.draw = () => {
-    p5.background(100);
+    p5.background(250);
     p5.normalMaterial();
-    p5.noStroke();
     p5.push();
-    p5.rotateY(rotation);
-    p5.box(100);
+    p5.rotateZ(p5.frameCount * 0.01);
+    p5.rotateX(p5.frameCount * 0.01);
+    p5.rotateY(p5.frameCount * 0.01);
+    p5.plane(100);
     p5.pop();
   };
 };
 
 export function App() {
-  const [rotation, setRotation] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(
-      () => setRotation(rotation => rotation + 100),
-      100
-    );
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
-  return <ReactP5Wrapper sketch={sketch} rotation={rotation} />;
+  return <ReactP5Wrapper sketch={sketch} />;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ of type `P5Instance`, you are good to go!
 
 ```ts
 import React from "react";
-import { ReactP5Wrapper } from "react-p5-wrapper";
+import { ReactP5Wrapper, P5Instance } from "react-p5-wrapper";
 
 function sketch(p5: P5Instance) {
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
@@ -118,7 +118,7 @@ that the `p5` argument passed to the sketch function is auto-typed as a
 
 ```ts
 import React from "react";
-import { ReactP5Wrapper } from "react-p5-wrapper";
+import { ReactP5Wrapper, Sketch } from "react-p5-wrapper";
 
 const sketch: Sketch = p5 => {
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ function sketch(p5) {
   };
 }
 
-export default function App() {
+export function App() {
   return <ReactP5Wrapper sketch={sketch} />;
 }
 ```
@@ -100,7 +100,7 @@ function sketch(p5) {
   p5.draw = draw(p5);
 }
 
-export default function App() {
+export function App() {
   return <ReactP5Wrapper sketch={sketch} />;
 }
 ```
@@ -143,7 +143,7 @@ function sketch(p5: P5Instance) {
   };
 }
 
-export default function App() {
+export function App() {
   const [rotation, setRotation] = useState(0);
 
   useEffect(() => {
@@ -199,7 +199,7 @@ const sketch: Sketch = p5 => {
   };
 };
 
-export default function App() {
+export function App() {
   const [rotation, setRotation] = useState(0);
 
   useEffect(() => {
@@ -261,7 +261,7 @@ function sketch(p5) {
   };
 }
 
-export default function App() {
+export function App() {
   const [rotation, setRotation] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION
This MR improves the README file by adding a new example of declaring a sketch in JavaScript.

Closes issue #127

## Proposed Changes

- Add an example of declaring a sketch using abstracted setup and draw functions.
- Use the same example in JavaScript and TypeScript sketches.

