### PR TITLE
Updates to docs, examples and tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,16 @@ TypeScript sketches can be declared in two different ways, below you will find
 two ways to declare a sketch, both examples do the exact same thing.
 
 In short though, the `ReactP5Wrapper` component requires you to pass a `sketch`
-prop. The `sketch` prop is typed as a `(instance: P5Instance): void;`. As long
-as the function declaration of your sketch is set to take in a single argument
-of type `P5Instance`, you are good to go!
+prop. The `sketch` prop is simply a function which takes a `p5` instance as it's
+first and only argument.
 
-#### Option 1: Declaring a sketch using the `P5Instance` type
+#### Option 1: Declaring a sketch using the `P5CanvasInstance` type
 
 ```typescript
 import React from "react";
-import { ReactP5Wrapper, P5Instance } from "react-p5-wrapper";
+import { ReactP5Wrapper, P5CanvasInstance } from "react-p5-wrapper";
 
-function sketch(p5: P5Instance) {
+function sketch(p5: P5CanvasInstance) {
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);
 
   p5.draw = () => {
@@ -106,15 +105,15 @@ export function App() {
 
 #### Option 2: Declaring a sketch using the `Sketch` type
 
-Using the `Sketch` type has one nice benefit over using `P5Instance` and that is
-that the `p5` argument passed to the sketch function is auto-typed as a
-`P5Instance` for you.
+Using the `Sketch` type has one nice benefit over using `P5CanvasInstance` and
+that is that the `p5` argument passed to the sketch function is auto-typed as a
+`P5CanvasInstance` for you.
 
 > Sidenote:
 >
 > In general it comes down to personal preference as to how you declare your
-> sketches and there is nothing wrong with using the `P5Instance` manually in a
-> regular `function` declaration.
+> sketches and there is nothing wrong with using the `P5CanvasInstance` manually
+> in a regular `function` declaration.
 
 ```typescript
 import React from "react";
@@ -166,17 +165,21 @@ This means, in these examples, that when the `rotation` prop that is provided as
 part of the `props` passed to the `updateWithProps` function, it will be
 correctly typed as a `number`.
 
-##### Usage with the `P5Instance` type
+##### Usage with the `P5CanvasInstance` type
 
 ```typescript
 import React, { useState, useEffect } from "react";
-import { ReactP5Wrapper, P5Instance, SketchProps } from "react-p5-wrapper";
+import {
+  ReactP5Wrapper,
+  P5CanvasInstance,
+  SketchProps
+} from "react-p5-wrapper";
 
 type MySketchProps = SketchProps & {
   rotation: number;
 };
 
-function sketch(p5: P5Instance<MySketchProps>) {
+function sketch(p5: P5CanvasInstance<MySketchProps>) {
   let rotation = 0;
 
   p5.setup = () => p5.createCanvas(600, 400, p5.WEBGL);

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -4,6 +4,8 @@ import { ReactP5Wrapper } from "../src/index.tsx";
 import * as box from "./sketches/box";
 import * as torus from "./sketches/torus";
 import "./example.css";
+import { useCallback } from "react";
+import { Fragment } from "react";
 
 function App() {
   const [state, setState] = useState({
@@ -11,45 +13,45 @@ function App() {
     sketch: box.sketch,
     unmount: false
   });
+  const onChangeSketch = useCallback(() => {
+    const useTorus = state.sketch === box.sketch;
+    const sketch = useTorus ? torus.sketch : box.sketch;
+
+    setState(state => ({ ...state, sketch }));
+  }, [state.sketch, box.sketch, torus.sketch]);
+  const onChangeRotation = useCallback(event => {
+    setState(state => ({
+      ...state,
+      rotation: parseInt(event.target.value, 10)
+    }));
+  }, []);
+  const onMountStateChange = useCallback(() => {
+    setState(state => ({ ...state, unmount: !state.unmount }));
+  });
+
+  if (state.unmount) {
+    return (
+      <Fragment>
+        <p>Unmounted the sketch</p>
+        <button onClick={onMountStateChange}>Remount</button>
+      </Fragment>
+    );
+  }
 
   return (
-    <>
-      {state.unmount ? (
-        <p>Unmounted the sketch</p>
-      ) : (
-        <ReactP5Wrapper sketch={state.sketch} rotation={state.rotation} />
-      )}
+    <Fragment>
+      <ReactP5Wrapper sketch={state.sketch} rotation={state.rotation} />
       <input
         type="range"
         defaultValue={state.rotation}
         min="0"
         max="360"
         step="1"
-        onChange={event => {
-          setState({
-            ...state,
-            rotation: parseInt(event.target.value, 10)
-          });
-        }}
+        onChange={onChangeRotation}
       />
-      <button
-        onClick={() => {
-          const useTorus = state.sketch === box.sketch;
-          setState({ ...state, sketch: useTorus ? torus.sketch : box.sketch });
-        }}
-      >
-        Change Sketch
-      </button>
-      {state.unmount ? (
-        <button onClick={() => setState({ ...state, unmount: false })}>
-          Remount
-        </button>
-      ) : (
-        <button onClick={() => setState({ ...state, unmount: true })}>
-          Unmount
-        </button>
-      )}
-    </>
+      <button onClick={onChangeSketch}>Change Sketch</button>
+      <button onClick={onMountStateChange}>Unmount</button>
+    </Fragment>
   );
 }
 

--- a/example/app.jsx
+++ b/example/app.jsx
@@ -1,11 +1,9 @@
-import React, { useState } from "react";
+import React, { Fragment, useState, useCallback } from "react";
 import { render } from "react-dom";
 import { ReactP5Wrapper } from "../src/index.tsx";
 import * as box from "./sketches/box";
 import * as torus from "./sketches/torus";
 import "./example.css";
-import { useCallback } from "react";
-import { Fragment } from "react";
 
 function App() {
   const [state, setState] = useState({
@@ -27,7 +25,7 @@ function App() {
   }, []);
   const onMountStateChange = useCallback(() => {
     setState(state => ({ ...state, unmount: !state.unmount }));
-  });
+  }, []);
 
   if (state.unmount) {
     return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,26 +58,39 @@ function ReactP5WrapperComponent<Props extends SketchProps = SketchProps>({
 
   useIsomorphicEffect(
     /**
-     * The `as any` cast is begrudgingly required due to a known limitation of the TypeScript compiler as demonstrated in issues:
+     * The `as unknown as Props` cast is begrudgingly required due to a known limitation of the TypeScript compiler as demonstrated in issues:
      *
      * - https://github.com/microsoft/TypeScript/issues/35858
      * - https://github.com/microsoft/TypeScript/issues/37670
      *
-     * Potentially this will be resolved by this PR once it is eventually merged:
+     * As Ryan Cavanaugh points out:
+     *
+     * "TS isn't capable of the higher-order reasoning needed to understand that Exclude<T, k> & { [k]: T[k] } is equivalent to T."
+     *
+     * For reference, this is the same issue as we face here just with `Omit` instead of `Exclude`.
+     *
+     * Potentially this would have been resolved by this PR but the author closed it due to lack of time:
      *
      * - https://github.com/microsoft/TypeScript/pull/42382
+     *
+     * Perhaps someone interested in the topic and who has time to work on it would be willing to take a look into the issue.
      *
      * Either way, until a resolution is merged into the TypeScript compiler that addresses this issue, we need to use this workaround.
      * We could also remove this if we manage find a reasonable, more fitting workaround of some sort to avoid casting in the first place.
      * If a workaround / change of implementation comes to mind, please raise an issue on the repository or feel free to open a PR!
      */
-    () => canvasInstanceRef.current?.updateWithProps?.(props as any),
+    () =>
+      canvasInstanceRef.current?.updateWithProps?.(props as unknown as Props),
     [props]
   );
 
   useIsomorphicEffect(() => () => removeCanvasInstance(canvasInstanceRef), []);
 
-  return <div ref={wrapperRef}>{children}</div>;
+  return (
+    <div ref={wrapperRef} className="react-p5-wrapper">
+      {children}
+    </div>
+  );
 }
 
 function propsAreEqual<Props extends SketchProps = SketchProps>(

--- a/tests/rendering.test.tsx
+++ b/tests/rendering.test.tsx
@@ -22,6 +22,12 @@ describe("Rendering", () => {
     expect(canvas).toBeInstanceOf(HTMLCanvasElement);
   });
 
+  it("[Client] Adds a utility css class to the wrapping element", () => {
+    const { container } = render(<ReactP5Wrapper sketch={sketch} />);
+
+    expect(container.firstElementChild!.className).toBe("react-p5-wrapper");
+  });
+
   it("[Client] Recreates the P5 instance when the sketch is changed", () => {
     const { container, rerender } = render(<ReactP5Wrapper sketch={sketch} />);
 
@@ -44,7 +50,7 @@ describe("Rendering", () => {
   it("[Server] Renders as expected when using `renderToString`", () => {
     const StringComponent = renderToString(<ReactP5Wrapper sketch={sketch} />);
 
-    expect(StringComponent).toBe(`<div></div>`);
+    expect(StringComponent).toBe('<div class="react-p5-wrapper"></div>');
   });
 
   it("[Server] Renders as expected when using `renderToStaticMarkup`", () => {
@@ -52,14 +58,14 @@ describe("Rendering", () => {
       <ReactP5Wrapper sketch={sketch} />
     );
 
-    expect(StaticComponent).toBe(`<div></div>`);
+    expect(StaticComponent).toBe('<div class="react-p5-wrapper"></div>');
   });
 
   it("[Server] Renders as expected when using `renderToNodeStream`", async () => {
     const nodeStream = renderToNodeStream(<ReactP5Wrapper sketch={sketch} />);
     const content = await unwrapReadableStream(nodeStream);
 
-    expect(content).toBe(`<div></div>`);
+    expect(content).toBe('<div class="react-p5-wrapper"></div>');
   });
 
   it("[Server] Renders as expected when using `renderToStaticNodeStream`", async () => {
@@ -68,6 +74,6 @@ describe("Rendering", () => {
     );
     const content = await unwrapReadableStream(staticNodeStream);
 
-    expect(content).toBe(`<div></div>`);
+    expect(content).toBe('<div class="react-p5-wrapper"></div>');
   });
 });


### PR DESCRIPTION
Fixes #164.

## Proposed Changes

- Update README to show expected usage of the `P5CanvasInstance` over the `P5Instance` type since this will be deprecated in the next major version.
- Update the code for the example to be more efficient and clean.
- Add a class to the wrapper for users who wish to target the wrapper or child elements with css. This was of course possible but the change here will make it "easier".

## Additional Notes (optional)

Fixes, if you can call it that, #164. I say "if you can call it that" since as I mentioned before, using css or js was previously possible for such use cases and this just makes it a little simpler with a class to specifically target other than P5s own one on the canvas proper.