### PR TITLE
Use pnpm to build examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To try them out for yourself, run the following:
 ```sh
 git clone git@github.com:P5-wrapper/react.git
 cd react
-npm install
-npm start
+pnpm install
+pnpm start
 ```
 
 Then just open `http://localhost:3001` in a browser.
@@ -441,5 +441,5 @@ To build, watch and serve the examples which will also watch the component
 source, run:
 
 ```sh
-  npm start
+  pnpm start
 ```


### PR DESCRIPTION
This PR proposes using the `pnpm` package manager to build the examples in the README documentation.

I think that after `pnpm` has been used as the main package manager, it's worth updating the documentation to build examples with it.

## Proposed Changes

- Use pnpm to build examples in README