### PR TITLE
Auto deploy to NPM in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -7,7 +7,7 @@ on:
 concurrency: cd-${{ github.ref }}
 
 jobs:
-  deploy:
+  gh-pages:
     runs-on: ubuntu-latest
     steps:
       - uses: P5-wrapper/setup-action@v1
@@ -21,3 +21,16 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist/demo
+
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: P5-wrapper/setup-action@v1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          # TODO: remove the dry run declaration after testing CD doesn't throw
+          dry-run: true


### PR DESCRIPTION
## Proposed Changes

- Automatically deploy to NPM on each master merge

## Additional Notes (optional)

Please read the [documentation](https://github.com/marketplace/actions/npm-publish) and suggest alternatives if you know of any better options or can find any. To me this seemed to be the simplest and offers a nice benefit (so it says) that if the version didn't change, it won't deploy at all which means we can control if it deploys or not purely by controlling the version within the `package.json` file.