### PR TITLE
Format lock file before creating commit

### DIFF
--- a/.github/workflows/UPDATE_DEPENDENCIES.yml
+++ b/.github/workflows/UPDATE_DEPENDENCIES.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Audit, update and install
         run: pnpm aui
 
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Formatting issues detected (attempting fix...)
+        if: ${{ failure() }}
+        run: pnpm format
+
       - name: Create dependency updates PR
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
This PR fixes the script for updating dependencies by formatting changes before creating a commit.

## Proposed Changes

- Add format step to the update dependencies script.
