### PR TITLE
Reset sourcemap style

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -36,7 +36,7 @@ function createBundleConfiguration(filename, format) {
     output: {
       file: filename,
       format,
-      sourcemap: "inline"
+      sourcemap: true
     },
     onwarn: warning => {
       throw new Error(warning.message);


### PR DESCRIPTION
## Proposed Changes

- Reset sourcemap style to keep consistency with previous releases

## Additional Notes (optional)

This was altered due to an issue in #194 but should be fine now.