### PR TITLE
fix incorrect variable name in plugin demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ const sketch: Sketch = p5 => {
 
     button.mousePressed(() => {
       if (!song) {
-        const songUrlPath = "/piano.mp3";
+        const songPath = "/piano.mp3";
         song = p5.loadSound(
           songPath,
           () => {


### PR DESCRIPTION
Tiny fix for an incorrect variable name in the readme.