### PR TITLE
fix: specify type declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "./dist/component/react.js",
   "exports": {
     ".": {
+      "types": "./dist/component/main.d.ts",
       "import": "./dist/component/react.js",
       "require": "./dist/component/react.umd.cjs"
     }


### PR DESCRIPTION
```ts
import { P5CanvasInstance, ReactP5Wrapper } from "@p5-wrapper/react";
```
This line causes the following error.
> There are types at '{project-path}/node_modules/@p5-wrapper/react/dist/component/main.d.ts', but this result could not be resolved when respecting package.json "exports". The '@p5-wrapper/react' library may need to update its package.json or typings.ts(7016)

It is resolved when specifying the type declaration file in package.json