### PR TITLE
change typescript module resolution to resolve typescript resolution …

### DIFF
--- a/config/typescript/tsconfig.json
+++ b/config/typescript/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "composite": true,
     "useDefineForClassFields": true,
     "types": ["vite/client"],
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/config/typescript/tsconfig.json
+++ b/config/typescript/tsconfig.json
@@ -12,7 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,

--- a/config/typescript/tsconfig.node.json
+++ b/config/typescript/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowSyntheticDefaultImports": true
   },
   "include": ["../vite/vite.component.config.ts"]

--- a/src/components/ReactP5WrapperGuard.tsx
+++ b/src/components/ReactP5WrapperGuard.tsx
@@ -17,9 +17,9 @@ const ErrorBoundary = React.lazy(() =>
   }))
 );
 
-export default function ReactP5WrapperGuard<Props extends SketchProps>(
+const ReactP5WrapperGuard = <Props extends SketchProps>(
   props: P5WrapperProps<Props>
-) {
+) => {
   if (props.sketch === undefined) {
     console.error("[ReactP5Wrapper] The `sketch` prop is required.");
 
@@ -52,3 +52,5 @@ export default function ReactP5WrapperGuard<Props extends SketchProps>(
     </ErrorBoundary>
   );
 }
+
+export default ReactP5WrapperGuard;

--- a/src/components/ReactP5WrapperWithSketch.tsx
+++ b/src/components/ReactP5WrapperWithSketch.tsx
@@ -9,9 +9,9 @@ import { removeCanvasInstance } from "../utils/removeCanvasInstance";
 import { updateCanvasInstance } from "../utils/updateCanvasInstance";
 import { withoutKeys } from "../utils/withoutKeys";
 
-export default function ReactP5WrapperWithSketch<Props extends SketchProps>(
+const ReactP5WrapperWithSketch = <Props extends SketchProps>(
   props: P5WrapperPropsWithSketch<Props>
-) {
+) => {
   const wrapperRef: WrapperRef = React.useRef(null);
   const canvasInstanceRef: CanvasInstanceRef<Props> = React.useRef(null);
   const userProvidedProps: SketchProps = React.useMemo(
@@ -49,3 +49,5 @@ export default function ReactP5WrapperWithSketch<Props extends SketchProps>(
     </div>
   );
 }
+
+export default ReactP5WrapperWithSketch;


### PR DESCRIPTION
…errors on build (#493)

Fixes #493

## Proposed Changes

- change module resolution to 'node', bundler fails to properly resolve type imports for whatever reason
- change default function exports to const and default exports (again, seems to be necessary probably because of some unique bundler issue) 

## Additional Notes (optional)
