### PR TITLE
Use OAuth token for Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
<!--
Thank you for contributing to @p5-wrapper/react!
Please fill out this template to help us review your PR as quickly as possible.
-->

## Related Issue

<!-- Please link to the issue this PR resolves -->

Fixes #558 (follow-up)

## PR Type

<!-- Please check one or more that apply by replacing [ ] with [x] -->

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Refactor
- [ ] 📝 Documentation Update
- [ ] 🧪 Test Update
- [x] 🔧 Build/CI Update
- [ ] 🧹 Chore
- [ ] ⏪ Revert

## Description

<!-- Please provide a clear and concise description of the changes made in this PR -->

Switches the Claude Code GitHub Action from API key authentication (`anthropic_api_key`) to OAuth token authentication (`claude_code_oauth_token`). This allows the action to use an existing Claude Max subscription instead of requiring separate API billing.

## Proposed Changes

<!-- List the specific changes made in this PR -->

- Replaced `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` with `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` in `.github/workflows/claude.yml`
-
-

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing (please describe)

The workflow change can be verified once the `CLAUDE_CODE_OAUTH_TOKEN` repository secret is configured (generated via `claude setup-token`). The old `ANTHROPIC_API_KEY` secret can then be removed.

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

N/A — CI configuration change only.

## Breaking Changes

<!-- Does this PR introduce breaking changes? If yes, please describe -->

- [ ] Yes (please describe)
- [x] No

## Checklist

<!-- Please check all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

<!-- Any additional information that might be helpful for reviewers -->

Before merging, ensure the `CLAUDE_CODE_OAUTH_TOKEN` repository secret has been created. Generate it locally with `claude setup-token` (requires a Claude Pro/Max subscription). After confirming the OAuth token works, the `ANTHROPIC_API_KEY` secret can be deleted.