### PR TITLE
Remove invalid workflows permission from Claude Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,7 +27,6 @@ jobs:
       issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
-      workflows: write # Required for Claude to push branches that include workflow file changes in history
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
<!--
Thank you for contributing to @p5-wrapper/react!
Please fill out this template to help us review your PR as quickly as possible.
-->

## Related Issue

<!-- Please link to the issue this PR resolves -->

Fixes broken workflow introduced in #571

## PR Type

<!-- Please check one or more that apply by replacing [ ] with [x] -->

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🔨 Code Refactor
- [ ] 📝 Documentation Update
- [ ] 🧪 Test Update
- [ ] 🔧 Build/CI Update
- [ ] 🧹 Chore
- [ ] ⏪ Revert

## Description

<!-- Please provide a clear and concise description of the changes made in this PR -->

Removes `workflows: write` from the Claude Code Action's job-level permissions block. This is not a valid permission at the job level and causes GitHub to reject the workflow file with: `Unexpected value 'workflows'`.

## Proposed Changes

<!-- List the specific changes made in this PR -->

- Removed `workflows: write` from `.github/workflows/claude.yml` permissions
-
-

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing (please describe)

The validation error was observed in [this action run](https://github.com/P5-wrapper/react/actions/runs/23926202361). Removing the line resolves the invalid workflow file error.

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

N/A — CI configuration change only.

## Breaking Changes

<!-- Does this PR introduce breaking changes? If yes, please describe -->

- [ ] Yes (please describe)
- [x] No

## Checklist

<!-- Please check all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

<!-- Any additional information that might be helpful for reviewers -->

The `workflows` scope is intentionally excluded from the Claude GitHub App for security reasons. It cannot be granted via job-level permissions either. When Claude needs to push branches whose git history includes workflow-modifying commits, a human must apply those changes manually.